### PR TITLE
Updated js-modules for jsbundling-rails v1.2.2+

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,7 +8,7 @@ html
     = csp_meta_tag
 
     = stylesheet_link_tag 'application'
-    = javascript_include_tag yield(:js_entrypoint).blank? ? 'application' : yield(:js_entrypoint)
+    = javascript_include_tag yield(:js_entrypoint).blank? ? 'application' : yield(:js_entrypoint), type: "module"
     = content_for :header
 
   body

--- a/bin/dev
+++ b/bin/dev
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-if ! gem list foreman -i --silent; then
+if gem list --no-installed --exact --silent foreman; then
   echo "Installing foreman..."
   gem install foreman
 fi

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -23,6 +23,7 @@ module.exports = {
   output: {
     filename: "[name].js",
     sourceMapFilename: "[file].map",
+    chunkFormat: "module",
     path: path.resolve(__dirname, "..", "..", "app/assets/builds"),
   },
   plugins: [


### PR DESCRIPTION
## Summary
Import application JS as a module

## Changes
- ES Modules
  - webpack config
  - html script tag

## Related URL
- jsbundling-rails 1.2.2
  - https://github.com/rails/jsbundling-rails/releases/tag/v1.2.2
  - https://github.com/rails/jsbundling-rails/compare/v1.2.1...v1.2.2



